### PR TITLE
Using nix for building staging

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30 
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       
       - name: Build the Vite app
         env:
@@ -40,7 +45,7 @@ jobs:
           echo "VITE_APP_AVAILABLE_CHAINS=${{ env.VITE_APP_AVAILABLE_CHAINS }}" >> .env
           echo "VITE_APP_DEFAULT_CHAIN=${{ env.VITE_APP_DEFAULT_CHAIN }}" >> .env
           cat .env | wc -l
-          bash scripts/build.sh
+          nix-shell --command "bash scripts/build.sh"
       
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@v0.5.3


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/deploy-staging.yaml` file to improve the build process by integrating Nix.

Build process improvements:

* Added a step to install Nix using `cachix/install-nix-action@v30` and set the `nix_path` to `nixpkgs=channel:nixos-unstable`. This ensures that the build environment is consistent and reproducible.
* Modified the build command to use `nix-shell` for executing the build script. This change leverages Nix to provide a clean and isolated shell environment for the build process.