### PR TITLE
Fix style that made close button have white background

### DIFF
--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -163,10 +163,7 @@ const MainContent = ({
               variant="ghost"
               size="sm"
               onClick={() => removeNotification(alert.key)}
-              className={`${isDark
-                ? 'text-[#FFFFFF] hover:text-[#E6007A]'
-                : 'text-[#670D35] hover:text-[#E6007A]'
-              }`}
+              className="bg-transparent text-[#670D35] hover:text-[#E6007A] dark:text-[#FFFFFF] dark:hover:text-[#E6007A]"
             >
               Dismiss
             </Button>


### PR DESCRIPTION
This pull request includes a small change to the `src/components/identity-registrar.tsx` file. The change simplifies the conditional class assignment for the `Button` component by using Tailwind CSS's dark mode utilities.

* [`src/components/identity-registrar.tsx`](diffhunk://#diff-7c003adab734ec85aed68ea749659c484c93c39a16fc1813056fc8212f984affL166-R166): Simplified the className attribute for the `Button` component to use Tailwind CSS's dark mode utilities.