### PR TITLE
(chore) Remove unused user store export from index.ts causing compile errors

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,1 +1,0 @@
-export * from './userSore'


### PR DESCRIPTION
This pull request includes a small change to the `src/store/index.ts` file. The change corrects a typo in the export statement by removing the incorrect export of `userSore`. 

* [`src/store/index.ts`](diffhunk://#diff-6617a8982092b70693d565d280deb361a2c860ca52f2a1d23f537ce5d276023bL1): Removed file containing unused & incorrect export statement for `userSore`.