### PR TITLE
Add Supported Fields Based on Registrar fields bit flags

### DIFF
--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -350,6 +350,7 @@ export function IdentityRegistrarComponent() {
           .map(([key, value]: [keyof IdentityFormData, IdentityData]) => [key, 
             (value.value as Binary).asText()
           ])
+          // TODO Handle other formats, like Blake2_256, etc.
         );
         identityStore.deposit = identityOf.deposit
         identityStore.info = identityData;

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -402,6 +402,42 @@ export function IdentityRegistrarComponent() {
   
   //#region chains
   const chainClient = useClient({ chainId: chainStore.id as keyof Chains })
+
+  const IdentityField = {
+    display: 1 << 0,
+    legal: 1 << 1,
+    web: 1 << 2,
+    matrix: 1 << 3,
+    email: 1 << 4,
+    pgpFingerprint: 1 << 5,
+    image: 1 << 6,
+    twitter: 1 << 7,
+    gitHub: 1 << 8,
+    discord: 1 << 9,
+  } as const;
+  const getSupportedFields = (bitfield: number): string[] => {
+    const result: string[] = [];
+    for (const key in IdentityField) {
+      if (bitfield & IdentityField[key as keyof typeof IdentityField]) {
+        result.push(key);
+      }
+    }
+    return result;
+  }
+
+  const _formattedChainId = (chainStore.name as string)?.split(' ')[0]?.toUpperCase()
+  const registrarIndex = import.meta.env[`VITE_APP_REGISTRAR_INDEX__PEOPLE_${_formattedChainId}`] as number
+  const [supportedFields, setSupportedFields] = useState<string[]>([])
+  useEffect(() => {
+    (typedApi.query.Identity.Registrars as ApiStorage)
+      .getValue()
+      .then((result) => {
+        const fields = result[registrarIndex].fields
+        const _supportedFields = getSupportedFields(fields > 0 ? Number(fields) : (1 << 10) -1)
+        setSupportedFields(_supportedFields)
+        if (import.meta.env.DEV) console.log({ supportedFields: _supportedFields, result })
+      })
+  }, [chainStore.id, typedApi, registrarIndex])
   
   useEffect(() => {
     ((async () => {

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -49,7 +49,6 @@ type MainContentProps = {
   typedApi: TypedApi<ChainDescriptorOf<keyof Chains>>, 
   accountStore: AccountData,
   chainConstants, 
-  isDark: boolean, 
   alertsStore: Map<string, AlertProps>,
   addNotification: any, 
   formatAmount: any, 
@@ -63,7 +62,7 @@ type MainContentProps = {
 }
 const MainContent = ({
   identityStore, challengeStore, chainStore, typedApi, accountStore,
-  chainConstants, isDark, alertsStore, identityFormRef, urlParams, isTxBusy,
+  chainConstants, alertsStore, identityFormRef, urlParams, isTxBusy, supportedFields,
   addNotification, removeNotification, formatAmount,
   signSubmitAndWatch, updateUrlParams, setOpenDialog,
 }: MainContentProps) => {
@@ -688,7 +687,7 @@ export function IdentityRegistrarComponent() {
   const onRequestWalletConnection = useCallback(() => setWalletDialogOpen(true), [])  
 
   const mainProps: MainContentProps = { 
-    chainStore, typedApi, accountStore, identityStore, chainConstants, isDark, alertsStore,
+    chainStore, typedApi, accountStore, identityStore, chainConstants, alertsStore,
     challengeStore: { challenges, error: challengeError }, identityFormRef, urlParams, isTxBusy,
     addNotification, removeNotification, formatAmount, 
     signSubmitAndWatch, updateUrlParams, setOpenDialog,

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -410,10 +410,10 @@ export function IdentityRegistrarComponent() {
     web: 1 << 2,
     matrix: 1 << 3,
     email: 1 << 4,
-    pgpFingerprint: 1 << 5,
+    pgp_fingerprint: 1 << 5,
     image: 1 << 6,
     twitter: 1 << 7,
-    gitHub: 1 << 8,
+    github: 1 << 8,
     discord: 1 << 9,
   } as const;
   const getSupportedFields = (bitfield: number): string[] => {

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -52,6 +52,7 @@ type MainContentProps = {
   alertsStore: Map<string, AlertProps>,
   addNotification: any, 
   formatAmount: any, 
+  supportedFields: string[],
   signSubmitAndWatch: any,
   removeNotification: any,
   identityFormRef: Ref<unknown>,
@@ -79,6 +80,7 @@ const MainContent = ({
         typedApi={typedApi}
         accountStore={accountStore}
         chainConstants={chainConstants}
+        supportedFields={supportedFields}
         formatAmount={formatAmount}
         signSubmitAndWatch={signSubmitAndWatch}
         isTxBusy={isTxBusy}
@@ -689,6 +691,7 @@ export function IdentityRegistrarComponent() {
   const mainProps: MainContentProps = { 
     chainStore, typedApi, accountStore, identityStore, chainConstants, alertsStore,
     challengeStore: { challenges, error: challengeError }, identityFormRef, urlParams, isTxBusy,
+    supportedFields,
     addNotification, removeNotification, formatAmount, 
     signSubmitAndWatch, updateUrlParams, setOpenDialog,
   }

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -597,7 +597,8 @@ export function IdentityRegistrarComponent() {
           }
         }
         else if (_result.type === "finalized") {
-          if (!_result.ok || !_result.found) {
+          // Tx need only be processed successfully. If Ok, it's already been found in best blocks.
+          if (!_result.ok) {
             addNotification({
               key: _result.txHash,
               type: "error",

--- a/src/components/tabs/IdentityForm.tsx
+++ b/src/components/tabs/IdentityForm.tsx
@@ -32,6 +32,7 @@ export const IdentityForm = forwardRef((
     typedApi,
     chainConstants,
     isTxBusy,
+    supportedFields,
     formatAmount,
     signSubmitAndWatch,
   }: {
@@ -41,6 +42,7 @@ export const IdentityForm = forwardRef((
     typedApi: TypedApi<ChainDescriptorOf<keyof Chains>>,
     chainConstants: Record<string, any>,
     isTxBusy: boolean,
+    supportedFields: string[],
     formatAmount: (amount: number | bigint | BigNumber | string, decimals?) => string,
     signSubmitAndWatch: (
       call: ApiTx,

--- a/src/components/tabs/IdentityForm.tsx
+++ b/src/components/tabs/IdentityForm.tsx
@@ -360,38 +360,41 @@ export const IdentityForm = forwardRef((
         <CardContent className="space-y-6 p-6">
 
           <form onSubmit={handleSubmit} className="space-y-4">
-            {Object.entries(identityFormFields).map(([key, props]) =>
-              <div className="space-y-2" key={props.key}>
-                <Label htmlFor="display-name" className="text-inherit flex items-center gap-2">
-                  {props.icon}
-                  {props.label}
-                </Label>
-                <Input
-                  id={props.key}
-                  name={props.key}
-                  value={formData[key].value}
-                  disabled={!accountStore.address}
-                  onChange={event => setFormData(_formData => {
-                    const newValue = event.target.value
-                    _formData = { ..._formData }
-                    _formData[key] = { ..._formData[key] }
-                    _formData[key].value = newValue;
-                    _formData[key].error = props.checkForErrors(newValue);
-                    if (identityFormFields[key].required && _formData[key].value === "") {
-                      _formData[key].error = "Required";
-                    }
-                    return _formData;
-                  })}
-                  placeholder={props.placeholder}
-                  className="bg-transparent border-[#E6007A] text-inherit placeholder-[#706D6D] focus:ring-[#E6007A]"
-                />
-                {formData[key].error && (
-                  <div className="text-[#E6007A] text-sm mt-1">
-                    <p>{formData[key].error}</p>
-                  </div>
-                )}
-              </div>
-            )}
+            {Object.entries(identityFormFields)
+              .filter(([key]) => supportedFields.includes(key))
+              .map(([key, props]) =>
+                <div className="space-y-2" key={props.key}>
+                  <Label htmlFor="display-name" className="text-inherit flex items-center gap-2">
+                    {props.icon}
+                    {props.label}
+                  </Label>
+                  <Input
+                    id={props.key}
+                    name={props.key}
+                    value={formData[key]?.value || ""}
+                    disabled={!accountStore.address}
+                    onChange={event => setFormData(_formData => {
+                      const newValue = event.target.value
+                      _formData = { ..._formData }
+                      _formData[key] = { ..._formData[key] }
+                      _formData[key].value = newValue;
+                      _formData[key].error = props.checkForErrors(newValue);
+                      if (identityFormFields[key].required && _formData[key].value === "") {
+                        _formData[key].error = "Required";
+                      }
+                      return _formData;
+                    })}
+                    placeholder={props.placeholder}
+                    className="bg-transparent border-[#E6007A] text-inherit placeholder-[#706D6D] focus:ring-[#E6007A]"
+                  />
+                  {formData[key]?.error && (
+                    <div className="text-[#E6007A] text-sm mt-1">
+                      <p>{formData[key].error}</p>
+                    </div>
+                  )}
+                </div>
+              )
+            }
             {forbiddenSubmission && (
               <div className="text-[#E6007A] text-sm mt-5">
                 <p>Please fill at least one field before proceeding. No validation errors allowed.</p>

--- a/src/components/tabs/IdentityForm.tsx
+++ b/src/components/tabs/IdentityForm.tsx
@@ -1,6 +1,8 @@
 import { forwardRef, Ref, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
 import { IdentityStore, verifyStatuses } from '@/store/IdentityStore'
-import { UserCircle, AtSign, Mail, MessageSquare, CheckCircle, Coins, AlertCircle, Globe } from 'lucide-react'
+import { 
+  UserCircle, AtSign, Mail, MessageSquare, CheckCircle, Coins, AlertCircle, Globe, Fingerprint, Github, Image, IdCard 
+} from 'lucide-react'
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -84,6 +86,128 @@ export const IdentityForm = forwardRef((
     setShowCostModal(true);
   }
 
+  const identityFormFields = {
+    display: {
+      label: "Display Name",
+      icon: <UserCircle className="h-4 w-4" />,
+      key: "display",
+      placeholder: 'Alice',
+      checkForErrors: (v) => v.length > 0 && v.length < 3 ? "At least 3 characters" : null,
+      required: false,
+    },
+    matrix: {
+      label: "Matrix",
+      icon: <AtSign className="h-4 w-4" />,
+      key: "matrix",
+      placeholder: '@alice:matrix.org',
+      checkForErrors: (v) => v.length > 0
+        && !/@[a-zA-Z0-9._=-]+:[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/i.test(v) ? "Invalid format" : null
+      ,
+      required: false,
+    },
+    email: {
+      label: "Email",
+      icon: <Mail className="h-4 w-4" />,
+      key: "email",
+      placeholder: 'alice@example.org',
+      checkForErrors: (v) => v.length > 0
+        && !/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(v) ? "Invalid format" : null,
+      required: false,
+    },
+    discord: {
+      label: "Discord",
+      icon: <MessageSquare className="h-4 w-4" />,
+      key: "discord",
+      placeholder: 'alice#1234',
+      checkForErrors: (v) => v.length > 0 && !/^[a-zA-Z0-9_]{2,32}(#\d+)?$/.test(v)
+        ? "Invalid format"
+        : null,
+      required: false,
+    },
+    twitter: {
+      label: "Twitter",
+      icon: <MessageSquare className="h-4 w-4" />,
+      key: "twitter",
+      placeholder: '@alice',
+      checkForErrors: (v) => v.length > 0 && !/^@?(\w){1,15}$/.test(v) ? "Invalid format" : null,
+      required: false,
+    },
+    web: {
+      label: "Website",
+      icon: <Globe className="h-4 w-4" />,
+      key: "web",
+      placeholder: 'alice.org',
+      checkForErrors: (v) => {
+        if (v.length === 0) return null;
+        try {
+          const url = new URL(v.startsWith('http') ? v : `https://${v}`);
+          return null;
+        } catch {
+          return "Invalid URL format";
+        }
+      },
+      transform: (value: string) => {
+        if (!value) return "";
+        return value.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+      },
+      required: false,
+    },
+    legal: {
+      label: "Legal Name",
+      icon: <IdCard className="h-4 w-4" />,
+      key: "legal",
+      placeholder: 'Alice',
+      checkForErrors: (v) => v.length > 0 && v.length < 3 ? "At least 3 characters" : null,
+      required: false,
+    },
+    image: {
+      label: "Image",
+      icon: <Image className="h-4 w-4" />,
+      key: "image",
+      placeholder: 'https://example.org/alice.png',
+      checkForErrors: (v) => {
+        if (v.length === 0) return null;
+        try {
+          new URL(v);
+          return null;
+        } catch {
+          return "Invalid URL format";
+        }
+      },
+      required: false,
+    },
+    github: {
+      label: "GitHub",
+      icon: <Github className="h-4 w-4" />,
+      key: "github",
+      placeholder: 'alice',
+      checkForErrors: (v) => v.length > 0 && !/^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$/.test(v)
+        ? "Invalid format"
+        : null,
+      required: false,
+    },
+    pgp_fingerprint: {
+      label: "PGP Fingerprint",
+      icon: <Fingerprint className="h-4 w-4" />,
+      key: "pgp_fingerprint",
+      placeholder: '0x1234...',
+      checkForErrors: (v) => v.length > 0 && !/^0x[a-fA-F0-9]{40}$/.test(v)
+        ? "Invalid format"
+        : null,
+      required: false,
+    }
+  }
+  const setId_requiredFields = [
+    "display", 
+    "legal",
+    "web", 
+    "matrix", 
+    "email", 
+    "image",
+    "twitter", 
+    "github", 
+    "discord", 
+  ]
   const getCall = useCallback((): ApiTx | null => {
     if (actionType === "judgement") {
       return typedApi.tx.Identity.request_judgement({
@@ -93,7 +217,12 @@ export const IdentityForm = forwardRef((
     } else if (actionType === "identity") {
       return typedApi.tx.Identity.set_identity({
         info: {
+          ...Object.fromEntries(setId_requiredFields.map(key => [ key, {type: "None"} ])),
           ...(Object.fromEntries(Object.entries(formData)
+            .map(([key, { value }]) => [key, identityFormFields[key].transform 
+              ? identityFormFields[key].transform(value)
+              : value
+            ])
             .map(([key, { value }]) => [key, value
               ? {
                 type: `Raw${value.length}`,
@@ -103,19 +232,8 @@ export const IdentityForm = forwardRef((
                 type: "None",
               }
             ])
+            // TODO Handle other field formats, e.g. Blake2_256, etc.
           )),
-          legal: {
-            type: "None",
-          },
-          github: {
-            type: "None",
-          },
-          image: {
-            type: "None",
-          },
-          // web: {
-          //   type: "None",
-          // },
         },
       });
     } 
@@ -179,73 +297,6 @@ export const IdentityForm = forwardRef((
     setShowCostModal(false)
   }, [getCall])
 
-  const identityFormFields = {
-    display: {
-      label: "Display Name",
-      icon: <UserCircle className="h-4 w-4" />,
-      key: "display",
-      placeholder: 'Alice',
-      checkForErrors: (v) => v.length > 0 && v.length < 3 ? "At least 3 characters" : null,
-      required: false,
-    },
-    matrix: {
-      label: "Matrix",
-      icon: <AtSign className="h-4 w-4" />,
-      key: "matrix",
-      placeholder: '@alice:matrix.org',
-      checkForErrors: (v) => v.length > 0 
-        && !/@[a-zA-Z0-9._=-]+:[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/i.test(v) ? "Invalid format" : null
-      ,
-      required: false,
-    },
-    email: {
-      label: "Email",
-      icon: <Mail className="h-4 w-4" />,
-      key: "email",
-      placeholder: 'alice@example.org',
-      checkForErrors: (v) => v.length > 0 
-        && !/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(v) ? "Invalid format" : null,
-      required: false,
-    },
-    discord: {
-      label: "Discord",
-      icon: <MessageSquare className="h-4 w-4" />,
-      key: "discord",
-      placeholder: 'alice#1234',
-      checkForErrors: (v) => v.length > 0 && !/^[a-zA-Z0-9_]{2,32}(#\d+)?$/.test(v) 
-        ? "Invalid format" 
-        : null,
-      required: false,
-    },
-    twitter: {
-      label: "Twitter",
-      icon: <MessageSquare className="h-4 w-4" />,
-      key: "twitter",
-      placeholder: '@alice',
-      checkForErrors: (v) => v.length > 0 && !/^@?(\w){1,15}$/.test(v) ? "Invalid format" : null,
-      required: false,
-    },
-    web: {
-      label: "Website",
-      icon: <Globe className="h-4 w-4" />,
-      key: "web",
-      placeholder: 'alice.org',
-      checkForErrors: (v) => {
-        if (v.length === 0) return null;
-        try {
-          const url = new URL(v.startsWith('http') ? v : `https://${v}`);
-          return null;
-        } catch {
-          return "Invalid URL format";
-        }
-      },
-      transform: (value: string) => {
-        if (!value) return "";
-        return value.replace(/^https?:\/\//, '').replace(/\/+$/, '');
-      },
-      required: false,
-    },
-  }
   const _resetFromIdStore = useCallback((identityStoreInfo) => (
     {...(Object.entries(identityFormFields).reduce((all, [key]) => {
       all[key] = {


### PR DESCRIPTION
This pull request includes several changes to the `identity-registrar` and `IdentityForm` components to enhance the handling of supported identity fields and improve the form's flexibility and functionality.

### Enhancements to `identity-registrar` component:

* Added a new `supportedFields` property to `MainContentProps` to dynamically handle supported identity fields. [[1]](diffhunk://#diff-7c003adab734ec85aed68ea749659c484c93c39a16fc1813056fc8212f984affL52-R55) [[2]](diffhunk://#diff-7c003adab734ec85aed68ea749659c484c93c39a16fc1813056fc8212f984affL66-R66) [[3]](diffhunk://#diff-7c003adab734ec85aed68ea749659c484c93c39a16fc1813056fc8212f984affR83) [[4]](diffhunk://#diff-7c003adab734ec85aed68ea749659c484c93c39a16fc1813056fc8212f984affL654-R694)
* Introduced a `getSupportedFields` function to determine supported fields based on a bitfield and updated the `IdentityRegistrarComponent` to use this function.

### Enhancements to `IdentityForm` component:

* Expanded the list of identity fields with additional options such as `legal`, `web`, `matrix`, `email`, `discord`, `twitter`, `image`, `github`, and `pgp_fingerprint`, each with validation and transformation logic. [[1]](diffhunk://#diff-c0ac4b6cfc9524ae8ebd72314b8bdd16a47c6fa5389529f1da3ed134e2156c5fR89-R210) [[2]](diffhunk://#diff-c0ac4b6cfc9524ae8ebd72314b8bdd16a47c6fa5389529f1da3ed134e2156c5fR220-R225) [[3]](diffhunk://#diff-c0ac4b6cfc9524ae8ebd72314b8bdd16a47c6fa5389529f1da3ed134e2156c5fR235-L116)
* Updated the form to filter and display only the supported fields based on the `supportedFields` property. [[1]](diffhunk://#diff-c0ac4b6cfc9524ae8ebd72314b8bdd16a47c6fa5389529f1da3ed134e2156c5fL310-R365) [[2]](diffhunk://#diff-c0ac4b6cfc9524ae8ebd72314b8bdd16a47c6fa5389529f1da3ed134e2156c5fL319-R374)
* Improved the handling of form data and error messages to ensure proper validation and user feedback.