### PR TITLE
Enhancements to Notification System and Fixes

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -3,8 +3,6 @@ import {
   polkadot_people,
   ksmcc3,
   ksmcc3_people,
-  rococo,
-  rococo_people,
   westend2,
   westend2_people,
   paseo,
@@ -44,6 +42,25 @@ export type ApiConfig = Config & {
     }
   >;
 };
+
+let rococoConfig = {};
+if (import.meta.env.DEV) {
+  if (import.meta.env.VITE_APP_DEFAULT_WS_URL && import.meta.env.VITE_APP_DEFAULT_WS_URL_RELAY) {
+    rococoConfig = {
+      rococo: {
+        name: "Rococo",
+        descriptor: await import("@polkadot-api/descriptors").then(mod => mod.rococo),
+        provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_DEFAULT_WS_URL_RELAY)),
+      },
+      rococo_people: {
+        name: "Rococo People",
+        descriptor: await import("@polkadot-api/descriptors").then(mod => mod.rococo_people),
+        provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_DEFAULT_WS_URL)),
+        registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_ROCOCO || 0,
+      },
+    };
+  }
+}
 export const config = defineConfig({
   chains: {
     polkadot: {
@@ -93,17 +110,7 @@ export const config = defineConfig({
       provider: providers.westend.addParachain({ id: "westend_people" }),
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_WESTEND,
     },
-    rococo: {
-      name: "Rococo",
-      descriptor: rococo,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_DEFAULT_WS_URL_RELAY)),
-    },
-    rococo_people: {
-      name: "Rococo People",
-      descriptor: rococo_people,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_DEFAULT_WS_URL)),
-      registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_ROCOCO,
-    }, 
+    ...rococoConfig,
   },
   targetChains: import.meta.env.VITE_APP_AVAILABLE_CHAINS 
     ? import.meta.env.VITE_APP_AVAILABLE_CHAINS.split(',').map(key => key.trim())

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -3,17 +3,8 @@ import {
   polkadot_people,
   ksmcc3,
   ksmcc3_people,
-  // rococo,
-  // rococo_people,
-  //  to enable add in .papi/polkadot-api.json and fetch metadata
-  // "rococo": {
-  //    "wsUrl": "wss://dev.rotko.net/paseo",
-  //    "metadata": ".papi/metadata/rococo.scale"
-  //  },
-  // "rococo_people": {
-  //    "wsUrl": "wss://dev.rotko.net/people-paseo",
-  //    "metadata": ".papi/metadata/rococo_people.scale"
-  //  },
+  rococo,
+  rococo_people,
   westend2,
   westend2_people,
   paseo,
@@ -102,7 +93,6 @@ export const config = defineConfig({
       provider: providers.westend.addParachain({ id: "westend_people" }),
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_WESTEND,
     },
-    /* Please refer to the note above to enable rococo chains
     rococo: {
       name: "Rococo",
       descriptor: rococo,
@@ -114,12 +104,10 @@ export const config = defineConfig({
       provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_DEFAULT_WS_URL)),
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_ROCOCO,
     }, 
-    */
   },
   targetChains: import.meta.env.VITE_APP_AVAILABLE_CHAINS 
     ? import.meta.env.VITE_APP_AVAILABLE_CHAINS.split(',').map(key => key.trim())
-    // : ["polkadot_people", "ksmcc3_people", "westend2_people", "rococo_people"]
-    : ["polkadot_people", "ksmcc3_people", "westend2_people"]
+    : ["polkadot_people", "ksmcc3_people", "westend2_people", "rococo_people"]
   ,
   wallets: [
     new InjectedWalletProvider(),

--- a/src/assets/icons/index.tsx
+++ b/src/assets/icons/index.tsx
@@ -1,0 +1,15 @@
+import { UserCircle, AtSign, Mail, XIcon, Globe, IdCard, Github, Fingerprint, Image } from "lucide-react";
+import { DiscordIcon } from "./discord";
+
+export const SOCIAL_ICONS = {
+  display: <UserCircle className="h-4 w-4" />,
+  matrix: <AtSign className="h-4 w-4" />,
+  email: <Mail className="h-4 w-4" />,
+  discord: <DiscordIcon className="h-4 w-4" />,
+  Twitter: <XIcon className="h-4 w-4" />,
+  web: <Globe className="h-4 w-4" />,
+  legal: <IdCard className="h-4 w-4" />,
+  image: <Image className="h-4 w-4" />,
+  github: <Github className="h-4 w-4" />,
+  pgp_fingerprint: <Fingerprint className="h-4 w-4" />,
+}

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -398,6 +398,13 @@ export function IdentityRegistrarComponent() {
   }, [accountStore.address, fetchIdAndJudgement])
   //#endregion identity
   
+  // Make sure to clear anything else that might change according to the chain or account
+  useEffect(() => {
+    alertsStore.forEach(alert => {
+      alertsStore.delete(alert.key)
+    })
+  }, [chainStore.id, accountStore.address])
+
   //#region chains
   const chainClient = useClient({ chainId: chainStore.id as keyof Chains })
 

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -510,7 +510,10 @@ export function IdentityRegistrarComponent() {
   //#region challenges
   const { challenges, 
     error: challengeError, 
-    isConnected: isChallengeWsConnected 
+    isConnected: isChallengeWsConnected,
+    subscribe: subscribeToChallenges,
+    connect: connectToChallenges,
+    disconnect: disconnectFromChallenges,
   } = useChallengeWebSocket({
     url: import.meta.env.VITE_APP_CHALLENGES_API_URL as string,
     address: accountStore.encodedAddress,
@@ -518,6 +521,11 @@ export function IdentityRegistrarComponent() {
     identityStore: { info: identityStore.info, status: identityStore.status, },
     addNotification,
   });
+  useEffect(() => {
+    if (isChallengeWsConnected && identityStore.status === verifyStatuses.FeePaid) {
+      subscribeToChallenges()
+    }
+  }, [isChallengeWsConnected])
   //#endregion challenges
 
   const formatAmount = useCallback((amount: number | bigint | BigNumber | string, decimals?) => {

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -379,6 +379,7 @@ export function IdentityRegistrarComponent() {
         identityStore.deposit = null
       }
       identityFormRef.current.reset()
+      return identityStore;
     })
     .catch(e => {
       if (import.meta.env.DEV) {
@@ -469,12 +470,19 @@ export function IdentityRegistrarComponent() {
     priority: number 
   }>>(() => ({
     "Identity.JudgementGiven": {
-      onEvent: data => {
-        fetchIdAndJudgement()
-        addNotification({
-          type: "info",
-          message: "Judgement Given for this account",
-        })
+      onEvent: async data => {
+        const newIdentity = await fetchIdAndJudgement()
+        if ((newIdentity as IdentityStore)?.status === verifyStatuses.IdentityVerified) {
+          addNotification({
+            type: "info",
+            message: "Judgement Given! Identity verified successfully. Congratulations!",
+          })
+        } else {
+          addNotification({
+            type: "error",
+            message: "Judgement Given! Identity not verified. Please remove it and try again.",
+          })
+        }
       },
       onError: error => { },
       priority: 4,

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -568,9 +568,11 @@ export function IdentityRegistrarComponent() {
         const _result: (typeof result) & {
           found: boolean,
           ok: boolean,
+          isValid: boolean,
         } = { 
           found: result["found"] || false,
           ok: result["ok"] || false,
+          isValid: result["isValid"],
           ...result,
         };
         if (result.type === "broadcasted") {
@@ -587,6 +589,15 @@ export function IdentityRegistrarComponent() {
               key: _result.txHash,
               type: "success",
               message: messages.success || "Transaction finalized",
+            })
+            fetchIdAndJudgement()
+            setTxBusy(false)
+          }
+          else if (!_result.isValid) {
+            addNotification({
+              key: _result.txHash,
+              type: "error",
+              message: messages.error || "Transaction failed because it's invalid",
             })
             fetchIdAndJudgement()
             setTxBusy(false)

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, startTransition, memo, useRef, Ref } from "react"
-import { ChevronLeft, ChevronRight, UserCircle, Shield, FileCheck, Coins, AlertCircle } from "lucide-react"
+import { ChevronLeft, ChevronRight, UserCircle, Shield, FileCheck, Coins, AlertCircle, Bell } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -37,6 +37,7 @@ import { ApiRuntimeCall, ApiStorage, ApiTx } from "~/types/api"
 import { GenericDialog } from "./dialogs/GenericDialog"
 import { Overview } from "~/help"
 import { HelpCarousel, SLIDES_COUNT } from "~/help/helpCarousel"
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "./ui/accordion"
 
 const MemoIdeitityForm = memo(IdentityForm)
 const MemoChallengesPage = memo(ChallengePage)
@@ -147,31 +148,46 @@ const MainContent = ({
   }, [currentTabIndex, enabledTabsIndexes, changeCurrentTab])
 
   return <>
-    {[...alertsStore.entries()].map(([, alert]) => (
-      <Alert
-        key={alert.key}
-        variant={alert.type === 'error' ? "destructive" : "default"}
-        className={`mb-4 ${alert.type === 'error'
-          ? 'bg-red-200 border-[#E6007A] text-red-800 dark:bg-red-800 dark:text-red-200'
-          : 'bg-[#FFE5F3] border-[#E6007A] text-[#670D35] dark:bg-[#393838] dark:text-[#FFFFFF]'
-        }`}
-      >
-        <AlertTitle>{alert.type === 'error' ? 'Error' : 'Notification'}</AlertTitle>
-        <AlertDescription className="flex justify-between items-center">
-          {alert.message}
-          {alert.closable === true && <>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => removeNotification(alert.key)}
-              className="bg-transparent text-[#670D35] hover:text-[#E6007A] dark:text-[#FFFFFF] dark:hover:text-[#E6007A]"
+    {alertsStore.size > 0 && 
+      <div className="fixed bottom-[2rem] right-[2rem] z-50 max-w-sm max-h-sm">  
+        <Accordion type="single" collapsible defaultValue="notifications">
+          <AccordionItem value="notifications">
+            <AccordionTrigger 
+              className="rounded-full p-2 bg-[#E6007A] text-[#FFFFFF] dark:bg-[#BC0463] dark:text-[#FFFFFF] hover:no-underline"
             >
-              Dismiss
-            </Button>
-          </>}
-        </AlertDescription>
-      </Alert>
-    ))}
+              <Bell className="h-6 w-6" /> {alertsStore.size}
+            </AccordionTrigger>
+            <AccordionContent className="bg-black/30 p-2 rounded-lg">
+              {[...alertsStore.entries()].map(([, alert]) => (
+                <Alert
+                  key={alert.key}
+                  variant={alert.type === 'error' ? "destructive" : "default"}
+                  className={`mb-4 ${alert.type === 'error'
+                    ? 'bg-red-200 border-[#E6007A] text-red-800 dark:bg-red-800 dark:text-red-200'
+                    : 'bg-[#FFE5F3] border-[#E6007A] text-[#670D35] dark:bg-[#393838] dark:text-[#FFFFFF]'
+                  }`}
+                >
+                  <AlertTitle>{alert.type === 'error' ? 'Error' : 'Notification'}</AlertTitle>
+                  <AlertDescription className="flex justify-between items-center">
+                    {alert.message}
+                    {alert.closable === true && <>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => removeNotification(alert.key)}
+                        className="bg-transparent text-[#670D35] hover:text-[#E6007A] dark:text-[#FFFFFF] dark:hover:text-[#E6007A]"
+                      >
+                        Dismiss
+                      </Button>
+                    </>}
+                  </AlertDescription>
+                </Alert>
+              ))}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </div>
+    }
 
     <Tabs defaultValue={tabs[0].name} value={tabs[currentTabIndex].name} className="w-full">
       <TabsList

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -587,7 +587,7 @@ export function IdentityRegistrarComponent() {
           })
         }
         else if (_result.type === "txBestBlocksState") {
-          if (_result.ok && _result.found) {
+          if (_result.ok) {
             addNotification({
               key: _result.txHash,
               type: "success",

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -401,7 +401,7 @@ export function IdentityRegistrarComponent() {
   // Make sure to clear anything else that might change according to the chain or account
   useEffect(() => {
     alertsStore.forEach(alert => {
-      alertsStore.delete(alert.key)
+      delete alertsStore[alert.key]
     })
   }, [chainStore.id, accountStore.address])
 

--- a/src/components/tabs/IdentityForm.tsx
+++ b/src/components/tabs/IdentityForm.tsx
@@ -1,7 +1,8 @@
 import { forwardRef, Ref, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
 import { IdentityStore, verifyStatuses } from '@/store/IdentityStore'
 import { 
-  UserCircle, AtSign, Mail, MessageSquare, CheckCircle, Coins, AlertCircle, Globe, Fingerprint, Github, Image, IdCard 
+  UserCircle, AtSign, Mail, MessageSquare, CheckCircle, Coins, AlertCircle, Globe, Fingerprint, Github, Image, IdCard, 
+  XIcon
 } from 'lucide-react'
 
 import { Button } from "@/components/ui/button"
@@ -19,6 +20,7 @@ import { IdentityStatusInfo } from '../IdentityStatusInfo'
 import { Observable } from 'rxjs'
 import { ChainDescriptorOf, Chains } from '@reactive-dot/core/internal.js'
 import { ApiTx } from '~/types/api'
+import { DiscordIcon } from '~/assets/icons/discord'
 
 // BUG Comflicts with IdentityFormData from ~/store/IdentityStore
 export type IdentityFormData = Record<string, {
@@ -116,7 +118,7 @@ export const IdentityForm = forwardRef((
     },
     discord: {
       label: "Discord",
-      icon: <MessageSquare className="h-4 w-4" />,
+      icon: <DiscordIcon className="h-4 w-4" />,
       key: "discord",
       placeholder: 'alice#1234',
       checkForErrors: (v) => v.length > 0 && !/^[a-zA-Z0-9_]{2,32}(#\d+)?$/.test(v)
@@ -126,7 +128,7 @@ export const IdentityForm = forwardRef((
     },
     twitter: {
       label: "Twitter",
-      icon: <MessageSquare className="h-4 w-4" />,
+      icon: <XIcon className="h-4 w-4" />,
       key: "twitter",
       placeholder: '@alice',
       checkForErrors: (v) => v.length > 0 && !/^@?(\w){1,15}$/.test(v) ? "Invalid format" : null,

--- a/src/components/tabs/StatusPage.tsx
+++ b/src/components/tabs/StatusPage.tsx
@@ -5,10 +5,11 @@ import { IdentityStore, verifyStatuses } from "~/store/IdentityStore"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
-import { AtSign, Mail, MessageSquare, UserCircle, CheckCircle, AlertCircle, Coins, Trash, FileCheck, Globe } from "lucide-react"
+import { AtSign, Mail, MessageSquare, UserCircle, CheckCircle, AlertCircle, Coins, Trash, FileCheck, Globe, XIcon } from "lucide-react"
 import BigNumber from "bignumber.js"
 import { IdentityStatusInfo } from "../IdentityStatusInfo"
 import { VerificationStatusBadge } from "../VerificationStatusBadge"
+import { SOCIAL_ICONS } from "~/assets/icons"
 
 export function StatusPage({
   identityStore,
@@ -26,22 +27,7 @@ export function StatusPage({
   onIdentityClear: () =>  void,
 }) {
   const getIcon = (field: string) => {
-    switch (field) {
-      case "matrix":
-        return <AtSign className="h-4 w-4" />
-      case "email":
-        return <Mail className="h-4 w-4" />
-      case "discord":
-        return <MessageSquare className="h-4 w-4" />
-      case "twitter":
-        return <MessageSquare className="h-4 w-4" />
-      case "web":
-        return <Globe className="h-4 w-4" />
-      case "display":
-        return <UserCircle className="h-4 w-4" />
-      default:
-        return null
-    }
+    return SOCIAL_ICONS[field] || <MessageSquare className="h-4 w-4" />
   }
 
   const onChainIdentity = identityStore.status

--- a/src/help/helpCarousel.tsx
+++ b/src/help/helpCarousel.tsx
@@ -28,7 +28,7 @@ export const HelpCarousel: React.FC<CarouselProps> = ({
   };
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center font-sans">
       <Carousel 
         className={twMerge("sm:w-[29rem] w-[74vw]", rest.className)} 
         showArrows={false} 

--- a/src/hooks/useChainRealTimeInfo.ts
+++ b/src/hooks/useChainRealTimeInfo.ts
@@ -36,66 +36,7 @@ export const useChainRealTimeInfo = ({ typedApi, chainId, address, handlers }: {
       })()
     }
   }, [typedApi])
-
-  const _pendingBlocks = useRef([])
-  useEffect(() => {
-    const timer = window.setInterval(() => {
-      [..._pendingBlocks.current]
-        .sort((b1, b2) => 
-          b2.neta.block.number*100 + handlers[b2.type].priority - b1.neta.block.number*100 + handlers[b1.type].priority 
-        )
-        .forEach(block => {
-          handlers[block.type].onEvent(block)
-          if (import.meta.env.DEV) console.log({ block, })
-        })
-      ;
-      _pendingBlocks.current = []
-    },  CHAIN_UPDATE_INTERVAL)
-    return () => {
-      window.clearInterval(timer)
-      _pendingBlocks.current = []
-    }
-  }, [])
-
-  // Since a single account is used, we can keep track of the last block per relevant event type. 
-  // This way we can avoid processing the same event multiple times.
-  const _lastBlockPerEvent = useRef({})
-  const waitForEvent = ({ type: { pallet, call }, }) => {
-    const type = `${pallet}.${call}`;
-    const { onError } = handlers[type]
-    typedApi.event[pallet][call].pull()
-      .then(data => {
-        if (data.length === 0) {
-          return
-        }
-        if (import.meta.env.DEV) console.log({ data, type, address })
-        data.filter(item => 
-          [item.payload.who, item.payload.target].includes(address)
-            && item.meta.block.number > (_lastBlockPerEvent.current[type] || 0)
-        )
-          .forEach(item => {
-            _pendingBlocks.current.push({ ...item, type })
-            _lastBlockPerEvent.current[type] = item.meta.block.number
-          })
-      })
-      .catch(error => {
-        onError(error)
-        if (import.meta.env.DEV) console.error({ message: error.message, type, })
-        if (import.meta.env.DEV) console.error(error)
-      })
-  }
-  const getEffectCallback = ({ type: { pallet, call }, }) => {
-    return () => {
-      if (!chainId || !address) {
-        return
-      }
-      const timer = window.setInterval(() => {
-        waitForEvent({ type: { pallet, call }, })
-      }, CHAIN_UPDATE_INTERVAL)
-      return () => window.clearInterval(timer)
-    }
-  }
-
+  
   // Convert handlers to array and memoize
   const handlerEntries = useMemo(() => 
     Object.entries(handlers).map(([key, handler]) => {
@@ -104,7 +45,7 @@ export const useChainRealTimeInfo = ({ typedApi, chainId, address, handlers }: {
     }), 
     [handlers]
   )
-  
+
   useEffect(() => {
     const systemEventsSub = (typedApi.query.System.Events as ApiStorage)
       .watchValue("best").subscribe({

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,14 +9,6 @@ import "react-responsive-carousel/lib/styles/carousel.min.css";
 import { Loading } from './pages/Loading'
 
 const Main: React.FC = () => {
-  useEffect(() => {
-    if (!import.meta.env.DEV) {
-      if (location.protocol !== 'https:') {
-        location.replace(`https:${location.href.substring(location.protocol.length)}`);
-      }
-    }
-  }, []);
-
   return <>
     <Suspense fallback={<Loading />}>
       <App />

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -1,10 +1,12 @@
 import type { Transaction, UnsafeTransaction, StorageDescriptor, TxOptions, RuntimeDescriptor } from "polkadot-api";
+import { Observable } from "rxjs";
 
 export type ApiTx = UnsafeTransaction<unknown | any, string, string, any> 
   | Transaction<unknown | any, string, string, any>
 
 export type ApiStorage = StorageDescriptor<any, any, boolean, string> & {
-  getValue: (...args: unknown, options?: TxOptions) => Promise<any>
+  getValue: (...args: unknown, options?: TxOptions) => Promise<any>,
+  watchValue: (...args: unknown, options?: TxOptions) => Observable<any>,
 }
 
 export type ApiRuntimeCall = RuntimeDescriptor<any>


### PR DESCRIPTION
This pull request includes significant updates to the configuration and functionality of the identity registrar component, as well as improvements to the handling of real-time chain information and WebSocket connections.

### Configuration Updates:
* Added dynamic configuration for local testnets, enabling them based on environment variables. (`src/api/config.ts`) [[1]](diffhunk://#diff-eea57ccd709e8924857189d8653b193294ff56e3a21a2a2d8a02b80ff830d9c7R45-R63) [[2]](diffhunk://#diff-eea57ccd709e8924857189d8653b193294ff56e3a21a2a2d8a02b80ff830d9c7L105-R117)

### Identity Registrar Component Enhancements:
* Introduced a notification system using an `Accordion` component to display alerts. (`src/components/identity-registrar.tsx`) (Fa89c9d5L147R183)
* Improved transaction handling by fetching the nonce dynamically and preventing duplicate notifications. (`src/components/identity-registrar.tsx`) [[1]](diffhunk://#diff-7c003adab734ec85aed68ea749659c484c93c39a16fc1813056fc8212f984affL516-R562) [[2]](diffhunk://#diff-7c003adab734ec85aed68ea749659c484c93c39a16fc1813056fc8212f984affR578-R599)
* Added logic to clear alerts when the chain or account changes. (`src/components/identity-registrar.tsx`)
* Enhanced the judgement notification to differentiate between successful and unsuccessful identity verifications. (`src/components/identity-registrar.tsx`)

### Real-Time Chain Information:
* Refactored the `useChainRealTimeInfo` hook to use the `System.Events` API for more efficient event handling. (`src/hooks/useChainRealTimeInfo.ts`) [[1]](diffhunk://#diff-e0defa2198ff97b0e21d5ca6156212682725bdd360aca5bc6bb93c2348e7159aL39-L97) [[2]](diffhunk://#diff-e0defa2198ff97b0e21d5ca6156212682725bdd360aca5bc6bb93c2348e7159aL107-R101)

### WebSocket Connection Enhancements:
* Extended the `useChallengeWebSocket` hook to include methods for subscribing, connecting, and disconnecting from the WebSocket. (`src/hooks/useChallengeWebSocket.ts`) [[1]](diffhunk://#diff-cd09c163d7123a248a73fb36d8c88b127efc2102d247407de032be232b46f1bcR112-R114) [[2]](diffhunk://#diff-cd09c163d7123a248a73fb36d8c88b127efc2102d247407de032be232b46f1bcL178-R185)