### PR TITLE
fix: add optional chaining to BalanceDisplay in Header component for …

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -121,7 +121,7 @@ const Header = ({
                               <span className="flex-shrink-0 pe-2">
                                 ({encodedAddress.substring(0, 4)}...{encodedAddress.substring(encodedAddress.length - 4, encodedAddress.length)})
                               </span>
-                              <BalanceDisplay balance={allAccountBalances[index].planck} formatter={shortFormatAmount} />
+                              <BalanceDisplay balance={allAccountBalances?.[index]?.planck} formatter={shortFormatAmount} />
                             </div>
                           </SelectItem>
                         );


### PR DESCRIPTION
This pull request includes a small change to the `Header` component in the `src/components/Header.tsx` file. The change ensures that the `BalanceDisplay` component handles cases where `allAccountBalances` or its nested properties might be undefined or null, which can cause a crash for first time users.

* [`src/components/Header.tsx`](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fL124-R124): Updated `BalanceDisplay` to use optional chaining for safer access to `allAccountBalances` and its nested properties.…safer access to account balances