### PR TITLE
Fix/faster rpc connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,16 @@ VITE_APP_WALLET_CONNECT_PROJECT_ID=rotko-w3-registrar
 VITE_APP_DEFAULT_WS_URL=wss://paseo-people.dotters.network
 VITE_APP_DEFAULT_WS_URL_RELAY=wss://paseo.dotters.network
 
+VITE_APP_POLKADOT_WS_URL=wss://polkadot.dotters.network
+VITE_APP_KUSAMA_WS_URL=wss://kusama.dotters.network
+VITE_APP_PASEO_WS_URL=wss://paseo.dotters.network
+VITE_APP_WESTEND_WS_URL=wss://westend.dotters.network
+
+VITE_APP_POLKADOT_PEOPLE_WS_URL=wss://people-polkadot.dotters.network
+VITE_APP_KUSAMA_PEOPLE_WS_URL=wss://people-kusama.dotters.network
+VITE_APP_PASEO_PEOPLE_WS_URL=wss://people-paseo.dotters.network
+VITE_APP_WESTEND_PEOPLE_WS_URL=wss://people-westend.dotters.network
+
 # fee 4,200,000,000
 VITE_APP_REGISTRAR_INDEX__PEOPLE_POLKADOT=5 
 # fee 42,000,000,000

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -103,7 +103,7 @@ export const config = defineConfig({
       name: "Westend People",
       symbol: "WND",
       descriptor: westend2_people,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_WESTEND_PEOPLE_WS_URL),
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_WESTEND_PEOPLE_WS_URL)),
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_WESTEND,
     },
     ...rococoConfig,

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -13,26 +13,10 @@ import { LedgerWallet } from "@reactive-dot/wallet-ledger";
 import { WalletConnect } from "@reactive-dot/wallet-walletconnect";
 import { registerDotConnect } from "dot-connect";
 import { getWsProvider } from "@polkadot-api/ws-provider/web";
-import { createLightClientProvider } from "@reactive-dot/core/providers/light-client.js";
 import { InjectedWalletProvider } from "@reactive-dot/core/wallets.js";
 import { withPolkadotSdkCompat } from "polkadot-api/polkadot-sdk-compat";
 
-const getProviders = () => {
-  const lightClientProvider = createLightClientProvider();
-  const polkadot = lightClientProvider.addRelayChain({ id: "polkadot" });
-  const ksmcc3 = lightClientProvider.addRelayChain({ id: "kusama" });
-  const paseo = lightClientProvider.addRelayChain({ id: "paseo" });
-  const westend = lightClientProvider.addRelayChain({ id: "westend" });
-
-  return {
-    lightClientProvider,
-    polkadot,
-    ksmcc3, 
-    paseo,
-    westend
-  };
-}
-export let providers = getProviders();
+// TODO Have additional WebSocket endpoint for each chain
 
 export type ApiConfig = Config & {
   chains: Record<
@@ -71,17 +55,13 @@ export const config = defineConfig({
       name: "Polkadot",
       symbol: "DOT",
       descriptor: polkadot,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_POLKADOT_WS_URL)) 
-        || providers.polkadot
-      ,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_POLKADOT_WS_URL)),
     },
     polkadot_people: {
       name: "Polkadot People",
       symbol: "DOT",
       descriptor: polkadot_people,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_POLKADOT_PEOPLE_WS_URL)) 
-        || providers.polkadot.addParachain({ id: "polkadot_people" })
-      ,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_POLKADOT_PEOPLE_WS_URL)),
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_POLKADOT,
     },
 
@@ -89,17 +69,13 @@ export const config = defineConfig({
       name: "Kusama",
       symbol: "KSM",
       descriptor: ksmcc3,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_KUSAMA_WS_URL)) 
-        || providers.ksmcc3
-      ,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_KUSAMA_WS_URL)),
     },
     ksmcc3_people: {
       name: "Kusama People",
       symbol: "KSM",
       descriptor: ksmcc3_people,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_KUSAMA_PEOPLE_WS_URL)) 
-        || providers.ksmcc3.addParachain({ id: "kusama_people" })
-      ,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_KUSAMA_PEOPLE_WS_URL)),
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_KUSAMA,
     },
 
@@ -107,17 +83,13 @@ export const config = defineConfig({
       name: "Paseo",
       symbol: "PAS",
       descriptor: paseo,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_PASEO_WS_URL)) 
-        || providers.paseo
-      ,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_PASEO_WS_URL)),
     },
     paseo_people: {
       name: "Paseo People",
       symbol: "PAS",
       descriptor: paseo_people,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_PASEO_PEOPLE_WS_URL)) 
-        || providers.paseo.addParachain({ id: "paseo_people" })
-      ,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_PASEO_PEOPLE_WS_URL)),
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_PASEO,
     },
 
@@ -125,17 +97,13 @@ export const config = defineConfig({
       name: "Westend",
       symbol: "WND",
       descriptor: westend2,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_WESTEND_WS_URL)) 
-        || providers.westend
-      ,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_WESTEND_WS_URL)),
     },
     westend2_people: {
       name: "Westend People",
       symbol: "WND",
       descriptor: westend2_people,
-      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_WESTEND_PEOPLE_WS_URL))
-        || providers.westend.addParachain({ id: "westend_people" })
-      ,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_WESTEND_PEOPLE_WS_URL),
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_WESTEND,
     },
     ...rococoConfig,

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -71,13 +71,17 @@ export const config = defineConfig({
       name: "Polkadot",
       symbol: "DOT",
       descriptor: polkadot,
-      provider: providers.polkadot,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_POLKADOT_WS_URL)) 
+        || providers.polkadot
+      ,
     },
     polkadot_people: {
       name: "Polkadot People",
       symbol: "DOT",
       descriptor: polkadot_people,
-      provider: providers.polkadot.addParachain({ id: "polkadot_people" }),
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_POLKADOT_PEOPLE_WS_URL)) 
+        || providers.polkadot.addParachain({ id: "polkadot_people" })
+      ,
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_POLKADOT,
     },
 
@@ -85,13 +89,17 @@ export const config = defineConfig({
       name: "Kusama",
       symbol: "KSM",
       descriptor: ksmcc3,
-      provider: providers.ksmcc3,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_KUSAMA_WS_URL)) 
+        || providers.ksmcc3
+      ,
     },
     ksmcc3_people: {
       name: "Kusama People",
       symbol: "KSM",
       descriptor: ksmcc3_people,
-      provider: providers.ksmcc3.addParachain({ id: "kusama_people" }),
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_KUSAMA_PEOPLE_WS_URL)) 
+        || providers.ksmcc3.addParachain({ id: "kusama_people" })
+      ,
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_KUSAMA,
     },
 
@@ -99,13 +107,17 @@ export const config = defineConfig({
       name: "Paseo",
       symbol: "PAS",
       descriptor: paseo,
-      provider: providers.paseo,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_PASEO_WS_URL)) 
+        || providers.paseo
+      ,
     },
     paseo_people: {
       name: "Paseo People",
       symbol: "PAS",
       descriptor: paseo_people,
-      provider: providers.paseo.addParachain({ id: "paseo_people" }),
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_PASEO_PEOPLE_WS_URL)) 
+        || providers.paseo.addParachain({ id: "paseo_people" })
+      ,
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_PASEO,
     },
 
@@ -113,13 +125,17 @@ export const config = defineConfig({
       name: "Westend",
       symbol: "WND",
       descriptor: westend2,
-      provider: providers.westend,
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_WESTEND_WS_URL)) 
+        || providers.westend
+      ,
     },
     westend2_people: {
       name: "Westend People",
       symbol: "WND",
       descriptor: westend2_people,
-      provider: providers.westend.addParachain({ id: "westend_people" }),
+      provider: withPolkadotSdkCompat(getWsProvider(import.meta.env.VITE_APP_WESTEND_PEOPLE_WS_URL))
+        || providers.westend.addParachain({ id: "westend_people" })
+      ,
       registrarIndex: import.meta.env.VITE_APP_REGISTRAR_INDEX__PEOPLE_WESTEND,
     },
     ...rococoConfig,


### PR DESCRIPTION
This pull request refactors the provider configuration in `src/api/config.ts` to simplify the codebase and improve maintainability. The changes remove the `createLightClientProvider` setup and replace it with direct WebSocket provider configurations using `withPolkadotSdkCompat` and `getWsProvider`.

### Refactoring of provider configuration:

* Removed the `createLightClientProvider` and its associated relay chain setup (`polkadot`, `kusama`, `paseo`, `westend`) in favor of a more streamlined approach using WebSocket endpoints. This simplifies the provider initialization logic.

* Updated the `provider` field for each chain configuration (e.g., `polkadot`, `kusama`, `paseo`, `westend`) to use `withPolkadotSdkCompat(getWsProvider(...))` with environment-specific WebSocket URLs. This ensures compatibility with the Polkadot SDK while maintaining flexibility for different environments.