### PR TITLE
UI: Show accounts outside connected wallet in order to add social media link sharing for on-chain identities

### DIFF
--- a/src/components/AccountsTree.tsx
+++ b/src/components/AccountsTree.tsx
@@ -362,8 +362,7 @@ export function AccountsTree({
   if (loading) {
     return (
       <div className={`space-y-4 ${className}`}>
-        <LoadingPlaceholder className="h-[50vh] w-full" />
-        <LoadingPlaceholder className="h-[20vh] w-full" />
+        <LoadingPlaceholder className="h-40 w-full" />
       </div>
     );
   }

--- a/src/components/AccountsTree.tsx
+++ b/src/components/AccountsTree.tsx
@@ -48,6 +48,7 @@ type AccountNodeProps = {
   onQuit: (node: AccountTreeNode) => void;
   isRemoving?: SS58String | null;
   formatAmount: (amount: bigint) => string;
+  hasWalletConnected?: boolean;
 };
 function AccountNode({
   node,
@@ -57,6 +58,7 @@ function AccountNode({
   onQuit,
   onRename,
   formatAmount,
+  hasWalletConnected,
   // TODO Pass currentNode, so we can get rid of isCurrentAccount abd isDirectSubOfCurrentAccount.
 }: AccountNodeProps) {
   return (
@@ -92,7 +94,7 @@ function AccountNode({
           {node.isCurrentAccount && <Badge variant="default" className="text-xs flex-grow-0 flex-shrink-1">Current</Badge>}
         </div>
 
-        <div className="flex flex-row gap-2 self-end">
+        {hasWalletConnected && <div className="flex flex-row gap-2 self-end">
           {!isRoot && node.isCurrentAccount && (
             <Button 
               size="icon" 
@@ -141,7 +143,7 @@ function AccountNode({
               )}
             </Button>
           )}
-        </div>
+        </div>}
       </div>
       
       {node.subs && node.subs.length > 0 
@@ -153,6 +155,7 @@ function AccountNode({
           onRename={onRename}
           onQuit={onQuit}
           formatAmount={formatAmount}
+          hasWalletConnected={hasWalletConnected}
         /> ))
       }
     </div>
@@ -170,6 +173,7 @@ type AccountsTreeProps = {
   identity: Identity;
   openTxDialog: (args: OpenTxDialogArgs_modeSet) => void;
   className?: string;
+  hasWalletConnected: boolean;
 };
 
 export function AccountsTree({
@@ -180,6 +184,7 @@ export function AccountsTree({
   identity,
   openTxDialog,
   className = "",
+  hasWalletConnected,
 }: AccountsTreeProps) {
   const [addingSubaccount, setAddingSubaccount] = useState(false);
   const [removingSubaccount, setRemovingSubaccount] = useState<SS58String | null>(null);
@@ -390,13 +395,14 @@ export function AccountsTree({
                 onRename={handleEditClick}
                 onQuit={quitSubaccount}
                 formatAmount={formattAmount}
+                hasWalletConnected={hasWalletConnected}
               />
             </div>
           )}
         </CardContent>
       </Card>
 
-      {currentAccountNode && (
+      {currentAccountNode && hasWalletConnected && (
         <Card>
           <CardHeader>
             <CardTitle>{isEditMode ? "Edit Subaccount" : "Add Subaccount"}</CardTitle>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -97,7 +97,7 @@ const Header = ({
               {connectedWallets.length > 0 && <>
                 <SelectItem value={{type: "Wallets"}}>Connect Wallets</SelectItem>
                 <SelectItem value={{type: "Disconnect"}}>Disconnect</SelectItem>
-                {identity.info && <>
+                {identity.info && accountStore.polkadotSigner && <>
                   <SelectItem value={{type: "RemoveIdentity"}}>Remove Identity</SelectItem>
                 </>}
                 <SelectSeparator />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,7 @@ const Header = ({
     symbol: string,
     tokenDecimals: number,
   };
-  accountStore: { address: string, name: string };
+  accountStore: { address: string, name: string, polkadotSigner: any };
   identity: Identity;
   isTxBusy: boolean;
   isDark: boolean;
@@ -87,7 +87,7 @@ const Header = ({
             <SelectTrigger className="w-full bg-transparent border-[#E6007A] text-inherit min-w-0">
               <div className="w-full min-w-0">
                 {(() => {
-                  if (accountStore.address) {
+                  if (accountStore.address && accountStore.polkadotSigner) {
                     return <AccountListing address={accountStore.address} name={accountStore.name} />;
                   }
                   if (connectedWallets.length > 0) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,11 +7,12 @@ import { useConnectedWallets, useSpendableBalance } from "@reactive-dot/react";
 import { PolkadotIdenticon } from 'dot-identicon/react.js';
 import { Identity } from "~/types/Identity";
 import { SelectLabel } from "@radix-ui/react-select";
-import { AccountData } from "~/store/AccountStore";
+import { Account, AccountData } from "~/store/AccountStore";
 import { Chains } from "@reactive-dot/core/internal.js";
 import { useFormatAmount } from "~/hooks/useFormatAmount";
 import { BalanceDisplay } from "./ui/balance-display";
 import { AssetAmount } from "~/types";
+import { ChainInfo } from "~/store/ChainStore";
 
 const AccountListing = ({ address, name }) => (
   <div className="flex items-center w-full min-w-0">
@@ -31,13 +32,8 @@ const Header = ({
 }: { 
   accounts: AccountData[];
   config: ApiConfig;
-  chainStore: {
-    id: string | number | symbol,
-    name: string,
-    symbol: string,
-    tokenDecimals: number,
-  };
-  accountStore: { address: string, name: string, polkadotSigner: any };
+  chainStore: ChainInfo;
+  accountStore: Account;
   identity: Identity;
   isTxBusy: boolean;
   isDark: boolean;
@@ -63,7 +59,7 @@ const Header = ({
     decimals: 2,
   })
   const formatAmount = useFormatAmount({
-    symbol: chainStore.symbol,
+    symbol: chainStore.tokenSymbol,
     tokenDecimals: chainStore.tokenDecimals,
   })
 

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -23,34 +23,10 @@ export const MainContent = ({
 }: MainContentProps) => {
   const tabs = [
     {
-      id: "identityForm",
-      name: "Identity Form",
-      icon: <UserCircle className="h-5 w-5" />,
-      disabled: false,
-      content: <div className="flex flex-col gap-4">
-        <MemoIdeitityForm
-          ref={identityFormRef}
-          identity={identity}
-          chainStore={chainStore}
-          typedApi={typedApi}
-          accountStore={accountStore}
-          chainConstants={chainConstants}
-          supportedFields={supportedFields}
-          openTxDialog={openTxDialog}
-          isTxBusy={isTxBusy}
-        />
-        <MemoChallengesPage
-          addNotification={addNotification}
-          challengeStore={challengeStore}
-          identity={identity}
-        />
-      </div>
-    },
-    {
       id: "status",
-      name: "Status",
+      name: "Profile",
       icon: <FileCheck className="h-5 w-5" />,
-      disabled: identity.status < verifyStatuses.NoIdentity,
+      disabled: false,
       content: <div className="flex flex-col gap-4">
         <MemoStatusPage
           identity={identity}
@@ -69,6 +45,29 @@ export const MainContent = ({
           openTxDialog={openTxDialog}
           className="pt-4"
         />
+      </div>
+    },
+    {
+      id: "identityForm",
+      name: "Identity Form",
+      icon: <UserCircle className="h-5 w-5" />,
+      disabled: false,
+      content: <div className="flex flex-col gap-4">
+        <MemoIdeitityForm
+          ref={identityFormRef}
+          identity={identity}
+          chainStore={chainStore}
+          typedApi={typedApi}
+          accountStore={accountStore}
+          chainConstants={chainConstants}
+          supportedFields={supportedFields}
+          openTxDialog={openTxDialog}
+          isTxBusy={isTxBusy}
+        />
+        {identity.status >= verifyStatuses.FeePaid && <MemoChallengesPage 
+          addNotification={addNotification} challengeStore={challengeStore}
+          identity={identity}
+        />}
       </div>
     },
   ]

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -58,7 +58,7 @@ export const MainContent = ({
       id: "identityForm",
       name: "Identity Form",
       icon: <UserCircle className="h-5 w-5" />,
-      disabled: false,
+      disabled: !accountStore.polkadotSigner,
       content: <div className="flex flex-col gap-4">
         <MemoIdeitityForm
           ref={identityFormRef}

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -35,6 +35,7 @@ export const MainContent = ({
           onIdentityClear={() => setOpenDialog("clearIdentity")}
           isTxBusy={isTxBusy}
           chainName={chainStore.name?.replace(/ People/g, " ")}
+          hasWalletConnected={!!accountStore.polkadotSigner}
         />
         <AccountsTree 
           identity={identity}
@@ -44,6 +45,7 @@ export const MainContent = ({
           api={typedApi}
           openTxDialog={openTxDialog}
           className="pt-4"
+          hasWalletConnected={!!accountStore.polkadotSigner}
         />
       </div>
     },

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, memo, useEffect } from "react"
-import { ChevronLeft, ChevronRight, UserCircle, Shield, FileCheck, ListTree } from "lucide-react"
+import { ChevronLeft, ChevronRight, UserCircle, IdCard } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -25,7 +25,7 @@ export const MainContent = ({
     {
       id: "status",
       name: "Profile",
-      icon: <FileCheck className="h-5 w-5" />,
+      icon: <IdCard className="h-5 w-5" />,
       disabled: false,
       content: <div className="flex flex-col gap-4">
         <MemoStatusPage

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -34,8 +34,13 @@ export const MainContent = ({
           formatAmount={formatAmount}
           onIdentityClear={() => setOpenDialog("clearIdentity")}
           isTxBusy={isTxBusy}
-          chainName={chainStore.name?.replace(/ People/g, " ")}
+          chainStore={{ 
+            name: chainStore.name?.replace(/ People/g, " "),
+            id: (chainStore.id as string).replace(/_people/g, ""),
+          }}
           hasWalletConnected={!!accountStore.polkadotSigner}
+          address={accountStore.encodedAddress}
+          addNotification={addNotification}
         />
         <AccountsTree 
           identity={identity}

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -713,16 +713,8 @@ export function IdentityRegistrarComponent() {
         <Header config={config} accounts={displayedAccounts} onChainSelect={onChainSelect} 
           onAccountSelect={onAccountSelect} identity={identity} 
           onRequestWalletConnections={onRequestWalletConnection}
-          accountStore={{
-            address: accountStore.encodedAddress,
-            name: accountStore.name,
-          }} 
-          chainStore={{
-            name: chainStore.name,
-            id: chainStore.id,
-            symbol: chainStore.tokenSymbol,
-            tokenDecimals: chainStore.tokenDecimals,
-          }} 
+          accountStore={accountStore} 
+          chainStore={chainStore} 
           onToggleDark={() => setDark(!isDark)}
           isDark={isDark}
           isTxBusy={isTxBusy}

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -47,6 +47,7 @@ import { useIdentity } from "~/hooks/useIdentity"
 import { useSupportedFields } from "~/hooks/useSupportedFields"
 import { useXcmParameters } from "~/hooks/useXcmParameters"
 import { useAccountsTree } from "~/hooks/UseAccountsTree"
+import { decodeAddress, encodeAddress } from "@polkadot/keyring"
 
 export function IdentityRegistrarComponent() {
   const {
@@ -98,7 +99,19 @@ export function IdentityRegistrarComponent() {
       })
       return;
     }
-    const accountData = getWalletAccount(urlParams.address);
+    let decodedAddress: Uint8Array;
+    try {
+      decodedAddress = decodeAddress(urlParams.address);
+    } catch (error) {
+      console.error("Error decoding address:", error);
+      return;
+    }
+    const accountData = getWalletAccount(decodedAddress) 
+      ?? [1, 2, 4, 8, 32, 33].includes(decodedAddress.length) ? {
+        address: urlParams.address,
+        encodeAddress: encodeAddress(decodedAddress, chainStore.ss58Format),
+      } : null
+    ;
     console.log({ accountData });
     if (accountData) {
       Object.assign(accountStore, accountData);

--- a/src/components/identity-registrar.tsx
+++ b/src/components/identity-registrar.tsx
@@ -107,10 +107,10 @@ export function IdentityRegistrarComponent() {
       return;
     }
     const accountData = getWalletAccount(decodedAddress) 
-      ?? [1, 2, 4, 8, 32, 33].includes(decodedAddress.length) ? {
+      ?? ([1, 2, 4, 8, 32, 33].includes(decodedAddress.length) ? {
         address: urlParams.address,
-        encodeAddress: encodeAddress(decodedAddress, chainStore.ss58Format),
-      } : null
+        encodedAddress: encodeAddress(decodedAddress, chainStore.ss58Format),
+      } : null)
     ;
     console.log({ accountData });
     if (accountData) {

--- a/src/components/tabs/IdentityForm.tsx
+++ b/src/components/tabs/IdentityForm.tsx
@@ -331,15 +331,15 @@ export const IdentityForm = forwardRef((
               </div>
             )}
             <IdentityStatusInfo status={identity.status} />
-            <div className="flex flex-col sm:flex-row gap-4 mt-4">
+            {accountStore.polkadotSigner && <div className="flex flex-col sm:flex-row gap-4 mt-4">
               <Button type="submit" disabled={forbiddenSubmission || isTxBusy}
                 className="bg-[#E6007A] text-[#FFFFFF] hover:bg-[#BC0463] flex-1"
               >
                 <CheckCircle className="mr-2 h-4 w-4" />
                 {onChainIdentity === verifyStatuses.NoIdentity ? 'Set Identity' : 'Update Identity'}
               </Button>
-              {onChainIdentity === verifyStatuses.IdentitySet && (
-                <Button type="button" variant="outline" disabled={forbiddenSubmission || isTxBusy}
+              {onChainIdentity === verifyStatuses.IdentitySet && accountStore.polkadotSigner && (
+                <Button type="button" variant="secondary" disabled={forbiddenSubmission || isTxBusy}
                   onClick={handleRequestJudgement}
                   className="border-[#E6007A] text-inherit hover:bg-[#E6007A] hover:text-[#FFFFFF] flex-1"
                 >
@@ -347,7 +347,7 @@ export const IdentityForm = forwardRef((
                   Request Judgement
                 </Button>
               )}
-            </div>
+            </div>}
           </form>
         </CardContent>
       </Card>

--- a/src/components/tabs/IdentityForm.tsx
+++ b/src/components/tabs/IdentityForm.tsx
@@ -38,7 +38,7 @@ export const IdentityForm = forwardRef((
     chainConstants: Record<string, any>,
     isTxBusy: boolean,
     supportedFields: string[],
-    openTxDialog: (darams: OpenTxDialogArgs) => void,
+    openTxDialog: (params: OpenTxDialogArgs) => void,
   },
   ref: Ref<unknown> & { reset: () => void },
 ) => {

--- a/src/components/tabs/StatusPage.tsx
+++ b/src/components/tabs/StatusPage.tsx
@@ -1,32 +1,40 @@
-import { Challenge, ChallengeStatus, ChallengeStore } from "~/store/challengesStore"
+import { Challenge, ChallengeStore } from "~/store/challengesStore"
 import { Identity, verifyStatuses } from "~/types/Identity"
 
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
-import { MessageSquare, UserCircle, CheckCircle, AlertCircle, Coins, Trash, FileCheck } from "lucide-react"
+import { MessageSquare, UserCircle, CheckCircle, AlertCircle, Coins, Trash, FileCheck, Share2 } from "lucide-react"
 import BigNumber from "bignumber.js"
 import { IdentityStatusInfo } from "../IdentityStatusInfo"
 import { VerificationStatusBadge } from "../VerificationStatusBadge"
 import { SOCIAL_ICONS } from "~/assets/icons"
 import { StatusBadge } from "../challenges/StatusBadge"
+import { SS58String } from "polkadot-api"
+import { AlertPropsOptionalKey } from "~/hooks/useAlerts"
 
 export function StatusPage({
   identity,
   challengeStore,
   isTxBusy,
-  chainName,
   formatAmount,
   onIdentityClear,
   hasWalletConnected,
+  address,
+  chainStore,
+  addNotification,
 }: {
   identity: Identity,
   challengeStore: ChallengeStore,
   isTxBusy: boolean,
-  chainName: string,
   formatAmount: (amount: number | bigint | BigNumber | string, decimals?) => string
   onIdentityClear: () =>  void,
   hasWalletConnected: boolean,
+  address: SS58String,
+  chainStore: {
+    name: string,
+    id: string,
+  },
+  addNotification: (AlertPropsOptionalKey) => void,
 }) {
   const getIcon = (field: string) => {
     return SOCIAL_ICONS[field] || <MessageSquare className="h-4 w-4" />
@@ -42,7 +50,7 @@ export function StatusPage({
           Identity Status
         </CardTitle>
         <CardDescription className="text-[#706D6D]">
-          This is the current status of your identity on the {chainName} chain.
+          This is the current status of your identity on the {chainStore.name} chain.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4 p-4">

--- a/src/components/tabs/StatusPage.tsx
+++ b/src/components/tabs/StatusPage.tsx
@@ -18,6 +18,7 @@ export function StatusPage({
   chainName,
   formatAmount,
   onIdentityClear,
+  hasWalletConnected,
 }: {
   identity: Identity,
   challengeStore: ChallengeStore,
@@ -25,6 +26,7 @@ export function StatusPage({
   chainName: string,
   formatAmount: (amount: number | bigint | BigNumber | string, decimals?) => string
   onIdentityClear: () =>  void,
+  hasWalletConnected: boolean,
 }) {
   const getIcon = (field: string) => {
     return SOCIAL_ICONS[field] || <MessageSquare className="h-4 w-4" />
@@ -106,14 +108,14 @@ export function StatusPage({
         </div>
         <IdentityStatusInfo status={identity.status} />
         <div className="flex flex-col sm:flex-row gap-4 mt-6">
-          <Button variant="outline" 
+          {hasWalletConnected && <Button variant="outline" 
             onClick={onIdentityClear} 
             className="border-[#E6007A] text-inherit hover:bg-[#E6007A] hover:text-[#FFFFFF] flex-1" 
             disabled={onChainIdentity <= verifyStatuses.NoIdentity || isTxBusy}
           >
             <Trash className="mr-2 h-4 w-4" />
             Clear Identity
-          </Button>
+          </Button>}
         </div>
       </CardContent>
     </Card>

--- a/src/components/tabs/StatusPage.tsx
+++ b/src/components/tabs/StatusPage.tsx
@@ -124,6 +124,28 @@ export function StatusPage({
             <Trash className="mr-2 h-4 w-4" />
             Clear Identity
           </Button>}
+          <Button variant="primary" className="flex-1" onClick={() => {
+            const url = `${window.location.origin}/?address=${address}&network=${chainStore.id}`;
+            navigator.clipboard.writeText(url)
+              .then(() => {
+                addNotification({
+                  type: "success",
+                  title: "Link Copied",
+                  message: "The link has been copied to your clipboard.",
+                  duration: 5000,
+                })
+              })
+              .catch(err => {
+                addNotification({
+                  type: "error",
+                  title: "Copy Failed",
+                  message: "Failed to copy the link.",
+                  duration: 5000,
+                })
+              });
+          }}>
+            <Share2 />Copy Link
+          </Button>
         </div>
       </CardContent>
     </Card>

--- a/src/hooks/UseAccountsTree.ts
+++ b/src/hooks/UseAccountsTree.ts
@@ -258,7 +258,7 @@ export const useAccountsTree = ({
       }
     } catch (err) {
       console.error("Error fetching account hierarchy:", err);
-      setError(err instanceof Error ? err : new Error(String(err)));
+      setError(err instanceof Error ? err : new Error(String(err), { cause: err }));
       setAccountTree(null);
     } finally {
       setLoading(false);

--- a/src/hooks/useWalletAccounts.tsx
+++ b/src/hooks/useWalletAccounts.tsx
@@ -30,13 +30,10 @@ export function useWalletAccounts({
   const getWalletAccount = useCallback((address: SS58String | Uint8Array) => {
     if (!address) return null;
     
-    let foundAccount: AccountData | null;
-    const decodedAddress: Uint8Array = typeof address === "string" ? decodeAddress(address) : address;
-    
-    foundAccount = accounts.find(account => {
-      const publicKey = account.polkadotSigner.publicKey;
-      return publicKey.every((byte, index) => byte === decodedAddress[index]);
-    });
+    const decodedAddress: Uint8Array = typeof address==="string" ? decodeAddress(address) : address;
+    const foundAccount = accounts.find(account => account.polkadotSigner.publicKey
+      .every((byte, index) => byte === decodedAddress[index])
+    );
 
     if (!foundAccount) {
       return null;
@@ -45,7 +42,7 @@ export function useWalletAccounts({
     return {
       name: foundAccount.name,
       polkadotSigner: foundAccount.polkadotSigner,
-      address: address,
+      address: foundAccount.address,
       encodedAddress: encodeAddress(foundAccount.polkadotSigner.publicKey, chainSs58Format),
     };
   }, [accounts, chainSs58Format]);

--- a/src/hooks/useWalletAccounts.tsx
+++ b/src/hooks/useWalletAccounts.tsx
@@ -27,17 +27,11 @@ export function useWalletAccounts({
   ), [accounts, chainSs58Format]);
 
   // Get wallet account by address
-  const getWalletAccount = useCallback((address: SS58String) => {
+  const getWalletAccount = useCallback((address: SS58String | Uint8Array) => {
     if (!address) return null;
     
     let foundAccount: AccountData | null;
-    let decodedAddress: Uint8Array;
-    try {
-      decodedAddress = decodeAddress(address);
-    } catch (error) {
-      console.error("Error decoding address:", error);
-      return null;
-    }
+    const decodedAddress: Uint8Array = typeof address === "string" ? decodeAddress(address) : address;
     
     foundAccount = accounts.find(account => {
       const publicKey = account.polkadotSigner.publicKey;

--- a/src/store/ChainStore.ts
+++ b/src/store/ChainStore.ts
@@ -1,7 +1,7 @@
 import { proxy } from "valtio";
 
 export interface ChainInfo {
-  id: string | number | symbol;
+  id: string | number | symbol; // TODO Leave this as string, as that's how we use it in the app
   name?: string;
   ss58Format?: number;
   tokenDecimals?: number;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,4 +1,5 @@
 import { TypedApi } from "polkadot-api"
+import { ChainInfo } from "~/store/ChainStore";
 
 export type DialogMode = "clearIdentity" |
   "disconnect" |


### PR DESCRIPTION
This pull request enhances the user experience by introducing identity link sharing, enabling account visibility beyond connected wallets, and improving wallet-aware UI behavior. These updates required significant internal refactoring to decouple identity and challenge data from wallet ownership, ensuring that public-facing account information is accessible without compromising interaction boundaries. Additional improvements include conditional tab rendering, stronger type consistency, and UI polish.

### Wallet-Aware UI Behavior and Public Account Access:  
* Added `hasWalletConnected` to `AccountNodeProps` and `AccountsTreeProps`, enabling the UI to distinguish between owned and non-owned accounts.  
* Refactored core data-fetching logic across identity, challenge status, and account hierarchy views to support visibility of public information regardless of wallet connection.  
* Ensured transactional elements (e.g., identity forms, signing actions) are conditionally hidden for accounts not controlled by the user's wallet, preventing interaction errors.  

### Identity Link Sharing:  
* Introduced a new “Copy Link” button in `StatusPage`, allowing users to copy a shareable link to their identity entry. The feature includes feedback via success and error notifications.  

### Tab Structure and Navigation:  
* Consolidated and restructured tab logic in `MainContent`, including conditional display of the Identity Form tab based on wallet connection.  
* Improved layout spacing and organization for better visual hierarchy and responsiveness.  

### Type and Error Handling Improvements:  
* Updated `Header` props to use precise `ChainInfo` and `Account` types, reducing type drift and increasing clarity.  
* Enhanced error tracking in `useAccountsTree` by attaching detailed causes to thrown exceptions.  

### UI/UX Enhancements and Code Cleanup:  
* Unified card styling across components for visual consistency.  
* Adjusted loading placeholders in `AccountsTree` to better fit into more contentful tabs, preventing loaders from using whole screen.  
* Removed unused imports and redundant logic, including the now-obsolete `ChallengeStatus` reference in `StatusPage`.  